### PR TITLE
Update the order that the FormRequest executes. 

### DIFF
--- a/src/Http/FormRequest.php
+++ b/src/Http/FormRequest.php
@@ -229,4 +229,27 @@ class FormRequest extends Request implements ValidatesWhenResolved
 
 		return $this;
 	}
+
+
+	/**
+	 * Validate the incoming request by checking the validations first then checking
+	 * the authorization.
+	 *
+	 * @return void
+	 * @throws AuthorizationException
+	 * @throws ValidationException
+	 */
+	public function validateResolved()
+	{
+
+		$validator = $this->getValidatorInstance();
+
+		if ($validator->fails()) {
+			$this->failedValidation($validator);
+		}
+
+		if (!$this->passesAuthorization()) {
+			$this->failedAuthorization();
+		}
+	}
 }


### PR DESCRIPTION
If a parameter is required and used inside the authorization, we should catch the parameter and perform a validation on it prior to doing anything else.